### PR TITLE
Add reusable color rotation helper

### DIFF
--- a/models/model.py
+++ b/models/model.py
@@ -1,5 +1,14 @@
+"""Simple visualisation of coloured points on circles.
+
+This module was originally a quick experiment and therefore performed the
+colour rotation inline using list slicing. To make the behaviour easier to
+test and reuse, the rotation logic now lives in :func:`utils.helpers.rotate_colors`.
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
+
+from utils.helpers import rotate_colors
 
 NUM_CIRCULOS = 2
 PUNTOS_POR_CIRCULO = 6
@@ -50,7 +59,7 @@ def on_click(event):
         dist = np.hypot(click_x - cx, click_y - cy)
         if dist <= RADIO:
             print(f'Clic en círculo {i}, rotando colores...')
-            circulos[i]['colores'] = circulos[i]['colores'][-1:] + circulos[i]['colores'][:-1]
+            circulos[i]['colores'] = rotate_colors(circulos[i]['colores'])
             dibujar()
             break
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import pytest
+
+# Ensure the project root is on the import path so ``utils`` can be imported
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from utils.helpers import rotate_colors
+
+
+def test_rotate_colors_single_step():
+    colors = ['red', 'blue', 'green']
+    assert rotate_colors(colors) == ['green', 'red', 'blue']
+    # Original list should remain unchanged
+    assert colors == ['red', 'blue', 'green']
+
+
+def test_rotate_colors_multiple_steps():
+    colors = ['a', 'b', 'c', 'd']
+    assert rotate_colors(colors, 2) == ['c', 'd', 'a', 'b']
+
+
+def test_rotate_colors_steps_wrap():
+    colors = [1, 2, 3]
+    # Rotating by a value larger than the list length should wrap around
+    assert rotate_colors(colors, 4) == [3, 1, 2]
+
+
+def test_rotate_colors_empty():
+    assert rotate_colors([]) == []

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,34 @@
+"""Utility helpers for the Rubik's cube project.
+
+Currently only contains a small helper to rotate a list of colours.
+"""
+from typing import Iterable, List, Sequence, TypeVar
+
+T = TypeVar("T")
+
+def rotate_colors(colors: Sequence[T], steps: int = 1) -> List[T]:
+    """Return a new list with ``colors`` rotated by ``steps`` positions.
+
+    Parameters
+    ----------
+    colors:
+        Sequence of elements to rotate. The original sequence is not modified.
+    steps:
+        Number of positions to rotate. Positive numbers rotate to the right.
+
+    Examples
+    --------
+    >>> rotate_colors(["red", "blue", "green"])
+    ['green', 'red', 'blue']
+    >>> rotate_colors([1, 2, 3, 4], 2)
+    [3, 4, 1, 2]
+    """
+    if not colors:
+        return []
+
+    n = len(colors)
+    steps %= n
+    if steps == 0:
+        return list(colors)
+
+    return list(colors[-steps:]) + list(colors[:-steps])


### PR DESCRIPTION
## Summary
- add `rotate_colors` helper to centralise colour list rotation
- use helper in `models/model.py` instead of inline slicing
- add tests covering rotation behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a725b3a90483238cc432d4cf4e6409